### PR TITLE
Ajout de AUTH_USER_MODEL au fichier settings

### DIFF
--- a/app/app/settings.py
+++ b/app/app/settings.py
@@ -123,3 +123,5 @@ STATIC_URL = 'static/'
 # https://docs.djangoproject.com/en/5.1/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+
+AUTH_USER_MODEL = 'django.contrib.auth.models.User'


### PR DESCRIPTION
Ajout de AUTH_USER_MODEL = 'django.contrib.auth.models.User' au fichier settings.py